### PR TITLE
Removed double inflated linearlayout (fixes #2), update Gradle, appcompat version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 22
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
     }

--- a/library/src/main/java/tr/xip/errorview/ErrorView.java
+++ b/library/src/main/java/tr/xip/errorview/ErrorView.java
@@ -16,11 +16,13 @@
 
 package tr.xip.errorview;
 
+import android.animation.LayoutTransition;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
@@ -46,18 +48,36 @@ public class ErrorView extends LinearLayout {
 
     private RetryListener mListener;
 
-    public ErrorView(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        init(attrs);
+    public ErrorView(Context context) {
+        this(context, null);
     }
 
-    private void init(AttributeSet attrs) {
-        TypedArray a = getContext().getTheme().obtainStyledAttributes(attrs, R.styleable.ErrorView, 0, 0);
+    public ErrorView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ErrorView(Context context, AttributeSet attrs, int defStyle) {
+        this(context, attrs, defStyle, 0);
+    }
+
+    public ErrorView(Context context, AttributeSet attrs, int defStyle, int defStyleRes) {
+        super(context, attrs);
+        init(attrs, defStyle, defStyleRes);
+    }
+
+    private void init(AttributeSet attrs, int defStyle, int defStyleRes) {
+        TypedArray a = getContext().getTheme().obtainStyledAttributes(attrs, R.styleable.ErrorView, defStyle, defStyleRes);
 
         LayoutInflater inflater = (LayoutInflater) getContext()
                 .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         inflater.inflate(R.layout.error_view_layout, this, true);
+        setOrientation(VERTICAL);
+        setGravity(Gravity.CENTER);
 
+        // Set android:animateLayoutChanges="true" programmatically
+        if (android.os.Build.VERSION.SDK_INT >= 11) {
+            setLayoutTransition(new LayoutTransition());
+        }
         mErrorImageView = (ImageView) findViewById(R.id.error_image);
         mTitleTextView = (TextView) findViewById(R.id.error_title);
         mSubtitleTextView = (TextView) findViewById(R.id.error_subtitle);

--- a/library/src/main/java/tr/xip/errorview/ErrorView.java
+++ b/library/src/main/java/tr/xip/errorview/ErrorView.java
@@ -53,7 +53,7 @@ public class ErrorView extends LinearLayout {
     }
 
     public ErrorView(Context context, AttributeSet attrs) {
-        this(context, attrs, 0);
+        this(context, attrs, R.attr.ev_style);
     }
 
     public ErrorView(Context context, AttributeSet attrs, int defStyle) {

--- a/library/src/main/res/layout/error_view_layout.xml
+++ b/library/src/main/res/layout/error_view_layout.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:animateLayoutChanges="true"
-    android:gravity="center"
-    android:orientation="vertical">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <ImageView
         android:id="@+id/error_image"
@@ -46,4 +40,4 @@
         android:text="@string/error_view_retry"
         android:textColor="@color/error_view_text_dark"
         android:textStyle="bold" />
-</LinearLayout>
+</merge>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <declare-styleable name="ErrorViewStyle">
+        <attr name="ev_style" format="reference" />
+    </declare-styleable>
+
     <declare-styleable name="ErrorView">
         <attr name="ev_title" format="string" />
         <attr name="ev_titleColor" format="color" />

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    compileSdkVersion 22
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         applicationId "tr.xip.errorview.sample"
         minSdkVersion 8
-        targetSdkVersion 21
+        targetSdkVersion 22
         versionCode Integer.parseInt(project.VERSION_CODE)
         versionName project.VERSION_NAME
     }
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:22.1.1'
     compile project(':library')
 }


### PR DESCRIPTION
Fixes for double inflated Linearlayout in ErrorView due to re-adding existing LinearLayout in inflated xml.
Added possibility to change attributes of ErrorView using application theme.
Also update Gradle version, build tools and plugins, including updating AppCompat library to 22.1.1.